### PR TITLE
adding error handling

### DIFF
--- a/lib/proofs/shuffling_proofs.go
+++ b/lib/proofs/shuffling_proofs.go
@@ -77,7 +77,7 @@ func checkShuffleProof(g, h kyber.Point, Xhat, Yhat, XhatBar, YhatBar []kyber.Po
 	err := proof.HashVerify(libunlynx.SuiTe, "PairShuffle", verifier, prf)
 
 	if err != nil {
-		log.LLvl1("-----------verify failed (with XharBar)")
+		log.Lvl1("-----------verify failed (with XhatBar)")
 		return false
 	}
 


### PR DESCRIPTION
Correctly handle errors in the `services/default/service.go` file.

Error handling is very important. Errors should never be ignored! The least you should do is to `log.Error`, but most often the error should be returned.