### PR TITLE
Small fix for medco-unlynx

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 as build
+FROM golang:1.12 as build
 
 COPY ./ /src
 

--- a/lib/aggregation/aggregation_proofs_test.go
+++ b/lib/aggregation/aggregation_proofs_test.go
@@ -7,12 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/lca1/unlynx/lib"
-	"go.dedis.ch/kyber/v3/util/key"
 )
 
 func TestAggregationProof(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	pubKey, _ := keys.Public, keys.Private
+	_, pubKey := libunlynx.GenKey()
 
 	tab1 := []int64{1, 2, 3, 6}
 	testCV1 := *libunlynx.EncryptIntVector(pubKey, tab1)

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -93,7 +93,7 @@ func NewDeterministicCipherVector(length int) *DeterministCipherVector {
 // Key Pairs
 //----------------------------------------------------------------------------------------------------------------------
 
-// GenKeys generates ElGamal public/private key pairs.
+// GenKey generate an ElGamal public/private key pair.
 func GenKey() (kyber.Scalar, kyber.Point) {
 	keys := key.NewKeyPair(SuiTe)
 	return keys.Private, keys.Public
@@ -106,9 +106,7 @@ func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 
 	group := SuiTe.Point().Null()
 	for i := 0; i < n; i++ {
-		keys := key.NewKeyPair(SuiTe)
-		pub[i] = keys.Public
-		priv[i] = keys.Private
+		priv[i], pub[i] = GenKey()
 		group.Add(group, pub[i])
 	}
 	return group, priv, pub

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -94,6 +94,12 @@ func NewDeterministicCipherVector(length int) *DeterministCipherVector {
 //----------------------------------------------------------------------------------------------------------------------
 
 // GenKeys generates ElGamal public/private key pairs.
+func GenKey() (kyber.Scalar, kyber.Point) {
+	keys := key.NewKeyPair(SuiTe)
+	return keys.Private, keys.Public
+}
+
+// GenKeys generates ElGamal public/private key pairs.
 func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 	priv := make([]kyber.Scalar, n)
 	pub := make([]kyber.Point, n)

--- a/lib/crypto_test.go
+++ b/lib/crypto_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/lca1/unlynx/lib"
 	"github.com/stretchr/testify/assert"
 	"go.dedis.ch/kyber/v3"
-	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/kyber/v3/util/random"
 	"go.dedis.ch/onet/v3/log"
 	"reflect"
@@ -15,8 +14,7 @@ import (
 
 // TestNullCipherText verifies encryption, decryption and behavior of null ciphertexts.
 func TestNullCipherText(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	nullEnc := libunlynx.EncryptInt(pubKey, 0)
 	nullDec := libunlynx.DecryptInt(secKey, *nullEnc)
@@ -37,8 +35,7 @@ func TestNullCipherText(t *testing.T) {
 
 // TestEncryption tests a relatively high number of encryptions.
 func TestEncryption(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 
 	nbrEncryptions := 10
 	for i := 0; i < nbrEncryptions; i++ {
@@ -47,8 +44,7 @@ func TestEncryption(t *testing.T) {
 }
 
 func TestEncryptIntVector(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 
 	nbrEncryptions := 200
 	arr := make([]int64, nbrEncryptions)
@@ -61,9 +57,7 @@ func TestEncryptIntVector(t *testing.T) {
 // TestDecryptionConcurrent test the multiple encryptions/decryptions at the same time
 func TestDecryptionConcurrent(t *testing.T) {
 	numThreads := 5
-
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	wg := libunlynx.StartParallelize(numThreads)
 
@@ -82,9 +76,7 @@ func TestDecryptionConcurrent(t *testing.T) {
 // TestDecryptionConcurrent test the multiple encryptions/decryptions at the same time
 func TestDecryptionNegConcurrent(t *testing.T) {
 	numThreads := 5
-
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	wg := libunlynx.StartParallelize(numThreads)
 
@@ -110,8 +102,7 @@ func TestDecryptionNegConcurrent(t *testing.T) {
 
 // TestNullCipherText verifies encryption, decryption and behavior of null cipherVectors.
 func TestNullCipherVector(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	nullVectEnc := *libunlynx.NullCipherVector(10, pubKey)
 	nullVectDec := libunlynx.DecryptIntVector(secKey, &nullVectEnc)
@@ -132,8 +123,7 @@ func TestNullCipherVector(t *testing.T) {
 
 // TestHomomorphicOpp tests homomorphic addition.
 func TestHomomorphicOpp(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	cv1 := libunlynx.EncryptIntVector(pubKey, []int64{0, 1, 2, 3, 100})
 	cv2 := libunlynx.EncryptIntVector(pubKey, []int64{0, 0, 1, 3, 3})
@@ -207,8 +197,7 @@ func TestAbstractPointsConverter(t *testing.T) {
 
 // TestCiphertextConverter tests the Ciphertext converter (to bytes)
 func TestCiphertextConverter(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := int64(2)
 	ct := libunlynx.EncryptInt(pubKey, target)
@@ -227,8 +216,7 @@ func TestCiphertextConverter(t *testing.T) {
 
 // TestCipherVectorConverter tests the CipherVector converter (to bytes)
 func TestCipherVectorConverter(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := []int64{0, 1, 3, 103, 103}
 	cv := libunlynx.EncryptIntVector(pubKey, target)
@@ -261,8 +249,7 @@ func TestIntArrayToCipherVector(t *testing.T) {
 }
 
 func TestB64Serialization(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := []int64{0, 1, 3, 103, 103}
 	cv := libunlynx.EncryptIntVector(pubKey, target)
@@ -291,8 +278,7 @@ func TestB64Serialization(t *testing.T) {
 }
 
 func TestEncryptScalar(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := int64(5)
 	scal := libunlynx.SuiTe.Scalar().SetInt64(target)
@@ -302,8 +288,7 @@ func TestEncryptScalar(t *testing.T) {
 }
 
 func TestEncryptScalarVector(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := []int64{0, 1, 3, 103, 103}
 	targetScal := make([]kyber.Scalar, len(target))
@@ -319,8 +304,7 @@ func TestEncryptScalarVector(t *testing.T) {
 }
 
 func TestDecryptIntVectorWithNeg(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := []int64{0, -1, -3, -103, -103}
 	cv := libunlynx.EncryptIntVector(pubKey, target)
@@ -332,8 +316,7 @@ func TestDecryptIntVectorWithNeg(t *testing.T) {
 }
 
 func TestDecryptCheckZero(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	ctZero := *libunlynx.EncryptInt(pubKey, int64(0))
 	assert.Equal(t, libunlynx.DecryptCheckZero(secKey, ctZero), int64(0))
@@ -343,8 +326,7 @@ func TestDecryptCheckZero(t *testing.T) {
 }
 
 func TestDecryptCheckZeroVector(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := []int64{0, 1, 5, 0, 3}
 
@@ -359,8 +341,7 @@ func TestDecryptCheckZeroVector(t *testing.T) {
 }
 
 func TestNewDeterministicCipherText(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, _ := keys.Private, keys.Public
+	secKey, _ := libunlynx.GenKey()
 
 	dt1 := libunlynx.NewDeterministicCipherText()
 	dt2 := libunlynx.NewDeterministicCipherText()
@@ -373,8 +354,7 @@ func TestNewDeterministicCipherText(t *testing.T) {
 }
 
 func TestNewDeterministicCipherVector(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, _ := keys.Private, keys.Public
+	secKey, _ := libunlynx.GenKey()
 
 	k := 5
 	dtv1 := *libunlynx.NewDeterministicCipherVector(k)
@@ -395,8 +375,7 @@ func TestNewDeterministicCipherVector(t *testing.T) {
 }
 
 func TestDeterministicCipherTextKey(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 
 	k := 5
 	target := []int64{0, 1, 3, 103, 103}
@@ -411,8 +390,7 @@ func TestDeterministicCipherTextKey(t *testing.T) {
 }
 
 func TestSerializePoint(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	target := int64(1)
 	ct := *libunlynx.EncryptInt(pubKey, target)

--- a/lib/deterministic_tag/deterministic_tag_proofs_test.go
+++ b/lib/deterministic_tag/deterministic_tag_proofs_test.go
@@ -7,15 +7,11 @@ import (
 	"github.com/lca1/unlynx/lib/deterministic_tag"
 	"github.com/stretchr/testify/assert"
 	"go.dedis.ch/kyber/v3"
-	"go.dedis.ch/kyber/v3/util/key"
 )
 
 func TestDeterministicTagProofCreation(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	pubKey, secKey := keys.Public, keys.Private
-	pubKeyNew := key.NewKeyPair(libunlynx.SuiTe).Public
-
-	secretContrib := key.NewKeyPair(libunlynx.SuiTe).Private
+	secKey, pubKey := libunlynx.GenKey()
+	secretContrib, pubKeyNew := libunlynx.GenKey()
 
 	cipherOne := *libunlynx.EncryptInt(pubKey, 10)
 
@@ -72,10 +68,8 @@ func TestDeterministicTagProofCreation(t *testing.T) {
 }
 
 func TestDeterministicTaggingAdditionProof(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	pubKey, secKey := keys.Public, keys.Private
-
-	secretContrib := key.NewKeyPair(libunlynx.SuiTe).Private
+	secKey, pubKey := libunlynx.GenKey()
+	secretContrib, _ := libunlynx.GenKey()
 
 	cipherOne := *libunlynx.EncryptInt(pubKey, 10)
 	toAdd := libunlynx.SuiTe.Point().Mul(secKey, libunlynx.SuiTe.Point().Base())

--- a/lib/deterministic_tag/deterministic_tag_proofs_test.go
+++ b/lib/deterministic_tag/deterministic_tag_proofs_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestDeterministicTagProofCreation(t *testing.T) {
 	secKey, pubKey := libunlynx.GenKey()
-	secretContrib, pubKeyNew := libunlynx.GenKey()
+	_, pubKeyNew := libunlynx.GenKey()
+	secretContrib, _ := libunlynx.GenKey()
 
 	cipherOne := *libunlynx.EncryptInt(pubKey, 10)
 

--- a/lib/key_switch/key_switch_proofs_test.go
+++ b/lib/key_switch/key_switch_proofs_test.go
@@ -15,7 +15,6 @@ import (
 // TesKeySwitchingProof test the creation and verification of key switching proofs
 func TestKeySwitchingProof(t *testing.T) {
 	keysTarget := key.NewKeyPair(libunlynx.SuiTe)
-
 	keys := key.NewKeyPair(libunlynx.SuiTe)
 
 	ct1 := libunlynx.EncryptInt(keys.Public, int64(1))

--- a/lib/key_switch/key_switch_test.go
+++ b/lib/key_switch/key_switch_test.go
@@ -14,8 +14,8 @@ import (
 // TesKeySwitchingProof test key switching of a sequence of ciphertexts
 func TestKeySwitchSequence(t *testing.T) {
 	keysTarget := key.NewKeyPair(libunlynx.SuiTe)
-
 	keys := key.NewKeyPair(libunlynx.SuiTe)
+
 	ct1 := libunlynx.EncryptInt(keys.Public, int64(1))
 	ct2 := libunlynx.EncryptInt(keys.Public, int64(2))
 

--- a/lib/structs_test.go
+++ b/lib/structs_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lca1/unlynx/lib/tools"
 	"github.com/stretchr/testify/assert"
 	"go.dedis.ch/kyber/v3"
-	"go.dedis.ch/kyber/v3/util/key"
 )
 
 // TestAddClientResponse tests the addition of two client response objects
@@ -18,8 +17,7 @@ func TestAddClientResponse(t *testing.T) {
 
 	sum := []int64{0, 2, 4, 6, 8}
 
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	cr1 := libunlynx.FilteredResponse{GroupByEnc: *libunlynx.EncryptIntVector(pubKey, grouping), AggregatingAttributes: *libunlynx.EncryptIntVector(pubKey, aggregating)}
 	cr2 := libunlynx.FilteredResponse{GroupByEnc: *libunlynx.EncryptIntVector(pubKey, grouping), AggregatingAttributes: *libunlynx.EncryptIntVector(pubKey, aggregating)}
@@ -34,8 +32,7 @@ func TestAddClientResponse(t *testing.T) {
 }
 
 func TestAddInMap(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 	gkey := libunlynx.GroupingKey("test")
 
 	cv := make(libunlynx.CipherVector, 5)
@@ -71,8 +68,7 @@ func decryptMapBytes(secKey kyber.Scalar, data map[string][]byte) (map[string]in
 
 // TestEncryptDpClearResponse tests the encryption of a DpClearResponse object
 func TestEncryptDpClearResponse(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	groupingClear := libunlynxtools.ConvertDataToMap([]int64{2}, "g", 0)
 	groupingEnc := libunlynxtools.ConvertDataToMap([]int64{1}, "g", len(groupingClear))
@@ -112,8 +108,7 @@ func TestFilteredResponseConverter(t *testing.T) {
 	grouping := []int64{1}
 	aggregating := []int64{0, 1, 3, 103, 103}
 
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	cr := libunlynx.FilteredResponse{GroupByEnc: *libunlynx.EncryptIntVector(pubKey, grouping), AggregatingAttributes: *libunlynx.EncryptIntVector(pubKey, aggregating)}
 
@@ -129,8 +124,7 @@ func TestFilteredResponseConverter(t *testing.T) {
 
 // TestFilteredResponseDetConverter tests the FilteredResponseDet converter (to bytes). In the meantime we also test the Key and UnKey function ... That is the way to go :D
 func TestClientResponseDetConverter(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	grouping := []int64{1}
 	aggregating := []int64{0, 1, 3, 103, 103}
@@ -156,8 +150,7 @@ func TestProcessResponseConverter(t *testing.T) {
 	grouping := []int64{1}
 	aggregating := []int64{0, 1, 3, 103, 103}
 
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	pr := libunlynx.ProcessResponse{
 		WhereEnc:              *libunlynx.EncryptIntVector(pubKey, whereEnc),
@@ -180,8 +173,7 @@ func TestProcessResponseDetConverter(t *testing.T) {
 	grouping := []int64{1}
 	aggregating := []int64{0, 1, 3, 103, 103}
 
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 
 	pr := libunlynx.ProcessResponse{
 		WhereEnc:              *libunlynx.EncryptIntVector(pubKey, whereEnc),
@@ -212,8 +204,7 @@ func TestProcessResponseDetConverter(t *testing.T) {
 }
 
 func TestDPResponseConverter(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	k := 5
 	dpResponseToSend := libunlynx.DpResponseToSend{
@@ -261,8 +252,7 @@ func TestDPResponseConverter(t *testing.T) {
 }
 
 func TestMapBytesToMapCipherText(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	k := 5
 	bMap := make(map[string][]byte)

--- a/protocols/tools_protocol_test.go
+++ b/protocols/tools_protocol_test.go
@@ -7,14 +7,12 @@ import (
 	"github.com/lca1/unlynx/lib"
 	"github.com/lca1/unlynx/protocols"
 	"github.com/stretchr/testify/assert"
-	"go.dedis.ch/kyber/v3/util/key"
 )
 
 // Create test for the further tools used in protocols and services to ensure shortly if a modification change the behaviour
 
 func TestRetrieveSimpleDataFromMap(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	secKey, pubKey := keys.Private, keys.Public
+	secKey, pubKey := libunlynx.GenKey()
 
 	k := 5
 	mapToTest := make(map[libunlynx.GroupingKey]libunlynx.FilteredResponse)
@@ -33,8 +31,7 @@ func TestRetrieveSimpleDataFromMap(t *testing.T) {
 }
 
 func TestProcessResponseToCipherVector(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 
 	testCipherVect := make(libunlynx.CipherVector, 1)
 	expRes := []int64{1}
@@ -77,8 +74,7 @@ func TestProcessResponseToCipherVector(t *testing.T) {
 }
 
 func TestProcessResponseToMatrixCipherText(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 
 	testCipherVect := make(libunlynx.CipherVector, 1)
 	expRes := []int64{1}
@@ -115,8 +111,7 @@ func TestProcessResponseToMatrixCipherText(t *testing.T) {
 }
 
 func TestAdaptCipherTextArray(t *testing.T) {
-	keys := key.NewKeyPair(libunlynx.SuiTe)
-	_, pubKey := keys.Private, keys.Public
+	_, pubKey := libunlynx.GenKey()
 
 	k := 5
 	cv := make(libunlynx.CipherVector, k)


### PR DESCRIPTION
1. Updated the golang version of docker deployment
2. Added a GenKey() function (we use this a lot in other repos) and refactored the code accordingly