### PR TITLE
Added a function to split a scalar into multiple scalars

### DIFF
--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -118,7 +118,6 @@ func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
 	for i := 0; i < nbrSplits; i++ {
 		allScalars[i] := RandomScalarSlice(1)[0]
 		rootScalar = rootScalar.Sub(rootScalar, allScalars[i])
-		allScalars = append(allScalars, newScalar)
 	}
 	allScalars = append(allScalars, rootScalar)
 

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -114,7 +114,7 @@ func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 
 // SplitScalar splits a given scalar into multiple n+1 scalars
 func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
-	allScalars := make([]kyber.Scalar, 0)
+	allScalars := make([]kyber.Scalar, nbrSplits)
 	for i := 0; i < nbrSplits; i++ {
 		newScalar := RandomScalarSlice(1)[0]
 		rootScalar = rootScalar.Sub(rootScalar, newScalar)

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -112,6 +112,19 @@ func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 	return group, priv, pub
 }
 
+// SplitScalar splits a given scalar into multiple n+1 scalars
+func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
+	allScalars := make([]kyber.Scalar, 0)
+	for i:=0; i<nbrSplits; i++ {
+		newScalar := RandomScalarSlice(1)[0]
+		rootScalar = rootScalar.Sub(rootScalar, newScalar)
+		allScalars = append(allScalars, newScalar)
+	}
+	allScalars = append(allScalars, rootScalar)
+
+	return allScalars
+}
+
 // Encryption
 //______________________________________________________________________________________________________________________
 

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -113,10 +113,11 @@ func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 }
 
 // SplitScalar splits a given scalar into multiple n+1 scalars
+// The sum of the returned slice of scalars equals the given `rootScalar`
 func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
 	allScalars := make([]kyber.Scalar, nbrSplits)
 	for i := range allScalars {
-		allScalars[i] := RandomScalarSlice(1)[0]
+		allScalars[i] = RandomScalarSlice(1)[0]
 		rootScalar = rootScalar.Sub(rootScalar, allScalars[i])
 	}
 	allScalars = append(allScalars, rootScalar)

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -116,7 +116,7 @@ func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
 	allScalars := make([]kyber.Scalar, nbrSplits)
 	for i := 0; i < nbrSplits; i++ {
-		newScalar := RandomScalarSlice(1)[0]
+		allScalars[i] := RandomScalarSlice(1)[0]
 		rootScalar = rootScalar.Sub(rootScalar, newScalar)
 		allScalars = append(allScalars, newScalar)
 	}

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -115,7 +115,7 @@ func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 // SplitScalar splits a given scalar into multiple n+1 scalars
 func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
 	allScalars := make([]kyber.Scalar, 0)
-	for i:=0; i<nbrSplits; i++ {
+	for i := 0; i < nbrSplits; i++ {
 		newScalar := RandomScalarSlice(1)[0]
 		rootScalar = rootScalar.Sub(rootScalar, newScalar)
 		allScalars = append(allScalars, newScalar)

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -117,7 +117,7 @@ func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
 	allScalars := make([]kyber.Scalar, nbrSplits)
 	for i := 0; i < nbrSplits; i++ {
 		allScalars[i] := RandomScalarSlice(1)[0]
-		rootScalar = rootScalar.Sub(rootScalar, newScalar)
+		rootScalar = rootScalar.Sub(rootScalar, allScalars[i])
 		allScalars = append(allScalars, newScalar)
 	}
 	allScalars = append(allScalars, rootScalar)

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -115,7 +115,7 @@ func GenKeys(n int) (kyber.Point, []kyber.Scalar, []kyber.Point) {
 // SplitScalar splits a given scalar into multiple n+1 scalars
 func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
 	allScalars := make([]kyber.Scalar, nbrSplits)
-	for i := 0; i < nbrSplits; i++ {
+	for i := range allScalars {
 		allScalars[i] := RandomScalarSlice(1)[0]
 		rootScalar = rootScalar.Sub(rootScalar, allScalars[i])
 	}

--- a/lib/crypto_test.go
+++ b/lib/crypto_test.go
@@ -33,6 +33,17 @@ func TestNullCipherText(t *testing.T) {
 
 }
 
+func TestSplitScalar(t *testing.T){
+	secKey, pubKey := libunlynx.GenKey()
+
+	scalars := libunlynx.SplitScalar(secKey, 8)
+	aggregate := libunlynx.SuiTe.Point().Mul(scalars[0], nil)
+	for i:=1; i<len(scalars); i++ {
+		aggregate = aggregate.Add(aggregate, libunlynx.SuiTe.Point().Mul(scalars[i], nil))
+	}
+	assert.Equal(t, pubKey.String(), aggregate.String())
+}
+
 // TestEncryption tests a relatively high number of encryptions.
 func TestEncryption(t *testing.T) {
 	_, pubKey := libunlynx.GenKey()

--- a/lib/crypto_test.go
+++ b/lib/crypto_test.go
@@ -33,12 +33,12 @@ func TestNullCipherText(t *testing.T) {
 
 }
 
-func TestSplitScalar(t *testing.T){
+func TestSplitScalar(t *testing.T) {
 	secKey, pubKey := libunlynx.GenKey()
 
 	scalars := libunlynx.SplitScalar(secKey, 8)
 	aggregate := libunlynx.SuiTe.Point().Mul(scalars[0], nil)
-	for i:=1; i<len(scalars); i++ {
+	for i := 1; i < len(scalars); i++ {
 		aggregate = aggregate.Add(aggregate, libunlynx.SuiTe.Point().Mul(scalars[i], nil))
 	}
 	assert.Equal(t, pubKey.String(), aggregate.String())


### PR DESCRIPTION
Easy peasy

``` go
// SplitScalar splits a given scalar into multiple n+1 scalars
func SplitScalar(rootScalar kyber.Scalar, nbrSplits int) []kyber.Scalar {
	allScalars := make([]kyber.Scalar, 0)
	for i:=0; i<nbrSplits; i++ {
		newScalar := RandomScalarSlice(1)[0]
		rootScalar = rootScalar.Sub(rootScalar, newScalar)
		allScalars = append(allScalars, newScalar)
	}
	allScalars = append(allScalars, rootScalar)

	return allScalars
}
```