### PR TITLE
lib.{Start,End}Parallelize: add error channel

### DIFF
--- a/data/handle_data_test.go
+++ b/data/handle_data_test.go
@@ -61,6 +61,6 @@ func TestCompareClearResponses(t *testing.T) {
 func TestComputeExpectedResult(t *testing.T) {
 	data, err := dataunlynx.ReadDataFromFile(filename)
 	assert.NoError(t, err)
-	assert.Equal(t, dataunlynx.CompareClearResponses(dataunlynx.ComputeExpectedResult(testData, 1, false), dataunlynx.ComputeExpectedResult(data, 1, false)), true, "Result should be the same")
-	assert.Equal(t, dataunlynx.CompareClearResponses(dataunlynx.ComputeExpectedResult(testData, 1, true), dataunlynx.ComputeExpectedResult(data, 1, true)), true, "Result should be the same")
+	assert.True(t, dataunlynx.CompareClearResponses(dataunlynx.ComputeExpectedResult(testData, 1, false), dataunlynx.ComputeExpectedResult(data, 1, false)), "Result should be the same")
+	assert.True(t, dataunlynx.CompareClearResponses(dataunlynx.ComputeExpectedResult(testData, 1, true), dataunlynx.ComputeExpectedResult(data, 1, true)), "Result should be the same")
 }

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -1,6 +1,7 @@
 package libunlynx
 
 import (
+	"errors"
 	"go.dedis.ch/onet/v3/log"
 	"os"
 	"time"
@@ -82,6 +83,23 @@ func (wg WaitGroupWithError) Wait() error {
 // StartParallelize starts parallelization by instanciating number of threads
 func StartParallelize(nbrWg uint) WaitGroupWithError {
 	return NewWaitGroupWithError(nbrWg)
+}
+
+// StartParallelizeWithInt starts parallelization by instanciating number of threads, channelling an error if nbrWg < 0
+func StartParallelizeWithInt(nbrWg int) WaitGroupWithError {
+	wrongArg := nbrWg < 0
+
+	if wrongArg {
+		nbrWg = 1
+	}
+
+	ret := NewWaitGroupWithError(uint(nbrWg))
+
+	if wrongArg {
+		ret.Done(errors.New("parallelization with negative number of worker"))
+	}
+
+	return ret
 }
 
 // EndParallelize waits for a number of threads to finish

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -3,7 +3,6 @@ package libunlynx
 import (
 	"go.dedis.ch/onet/v3/log"
 	"os"
-	"sync"
 	"time"
 
 	"go.dedis.ch/onet/v3/simul/monitor"
@@ -48,14 +47,44 @@ func EndTimer(timer *monitor.TimeMeasure) {
 	}
 }
 
+// WaitGroupWithError is like a sync.WaitGroup, with an error channel
+type WaitGroupWithError struct {
+	waiter  chan error
+	counter uint
+}
+
+// NewWaitGroupWithError creates a new WaitGroupWithError for the given count
+func NewWaitGroupWithError(count uint) WaitGroupWithError {
+	return WaitGroupWithError{
+		waiter:  make(chan error, count),
+		counter: count,
+	}
+}
+
+// Done mark the end of a goroutine, it has to be called, even with nil error
+func (wg WaitGroupWithError) Done(err error) {
+	wg.waiter <- err
+}
+
+// Wait waits for all expected goroutine to finish, returning the first error encountered
+func (wg WaitGroupWithError) Wait() error {
+	var ret error
+
+	for i := uint(0); i < wg.counter; i++ {
+		if err := <-wg.waiter; ret == nil && err != nil {
+			ret = err
+		}
+	}
+
+	return ret
+}
+
 // StartParallelize starts parallelization by instanciating number of threads
-func StartParallelize(nbrWg int) *sync.WaitGroup {
-	var wg sync.WaitGroup
-	wg.Add(nbrWg)
-	return &wg
+func StartParallelize(nbrWg uint) WaitGroupWithError {
+	return NewWaitGroupWithError(nbrWg)
 }
 
 // EndParallelize waits for a number of threads to finish
-func EndParallelize(wg *sync.WaitGroup) {
-	wg.Wait()
+func EndParallelize(wg WaitGroupWithError) error {
+	return wg.Wait()
 }

--- a/lib/crypto_test.go
+++ b/lib/crypto_test.go
@@ -1,6 +1,7 @@
 package libunlynx_test
 
 import (
+	"fmt"
 	"github.com/ldsec/unlynx/lib"
 	"github.com/stretchr/testify/assert"
 	"go.dedis.ch/kyber/v3"
@@ -67,33 +68,28 @@ func TestEncryptIntVector(t *testing.T) {
 
 // TestDecryptionConcurrent test the multiple encryptions/decryptions at the same time
 func TestDecryptionConcurrent(t *testing.T) {
-	numThreads := 5
+	numThreads := uint(5)
 	secKey, pubKey := libunlynx.GenKey()
 
-	wg := libunlynx.StartParallelize(numThreads)
+	for i := uint(0); i < numThreads; i++ {
+		t.Run(fmt.Sprintf("TestDecryptionConcurrent/%v", i), func(t *testing.T) {
+			t.Parallel()
 
-	for i := 0; i < numThreads; i++ {
-		wg.Done()
-		go func() {
 			ct := libunlynx.EncryptInt(pubKey, 0)
 			val := libunlynx.DecryptInt(secKey, *ct)
 			assert.Equal(t, val, int64(0))
-		}()
+		})
 	}
-
-	libunlynx.EndParallelize(wg)
 }
 
 // TestDecryptionConcurrent test the multiple encryptions/decryptions at the same time
 func TestDecryptionNegConcurrent(t *testing.T) {
-	numThreads := 5
+	numThreads := uint(5)
 	secKey, pubKey := libunlynx.GenKey()
 
-	wg := libunlynx.StartParallelize(numThreads)
-
-	for i := 0; i < numThreads; i++ {
-		go func() {
-			wg.Done()
+	for i := uint(0); i < numThreads; i++ {
+		t.Run(fmt.Sprintf("TestDecryptionNegConcurrent/%v", i), func(t *testing.T) {
+			t.Parallel()
 
 			ct := libunlynx.EncryptInt(pubKey, 3)
 			val := libunlynx.DecryptIntWithNeg(secKey, *ct)
@@ -106,9 +102,8 @@ func TestDecryptionNegConcurrent(t *testing.T) {
 			ct = libunlynx.EncryptInt(pubKey, -3)
 			val = libunlynx.DecryptIntWithNeg(secKey, *ct)
 			assert.Equal(t, val, int64(-3))
-		}()
+		})
 	}
-	libunlynx.EndParallelize(wg)
 }
 
 // TestNullCipherText verifies encryption, decryption and behavior of null cipherVectors.

--- a/protocols/utils/local_clear_aggregation_protocol.go
+++ b/protocols/utils/local_clear_aggregation_protocol.go
@@ -42,7 +42,7 @@ func NewLocalClearAggregationProtocol(n *onet.TreeNodeInstance) (onet.ProtocolIn
 	return pvp, nil
 }
 
-var finalResultClearAggr = make(chan []libunlynx.DpClearResponse)
+var finalResultClearAggr = make(chan []libunlynx.DpClearResponse, 1)
 
 // Start is called at the root to start the execution of the local clear aggregation.
 func (p *LocalClearAggregationProtocol) Start() error {

--- a/protocols/utils/local_clear_aggregation_test.go
+++ b/protocols/utils/local_clear_aggregation_test.go
@@ -32,10 +32,7 @@ func TestLocalClearAggregation(t *testing.T) {
 	protocol.TargetOfAggregation = testData
 	feedback := protocol.FeedbackChannel
 
-	go func() {
-		err := protocol.Start()
-		assert.NoError(t, err)
-	}()
+	assert.NoError(t, protocol.Start())
 
 	timeout := network.WaitRetry * time.Duration(network.MaxRetryConnect*10) * time.Millisecond
 

--- a/simul/addrm_server_simul.go
+++ b/simul/addrm_server_simul.go
@@ -54,7 +54,6 @@ func (sim *AddRmSimulation) Setup(dir string, hosts []string) (*onet.SimulationC
 // Run starts the simulation.
 func (sim *AddRmSimulation) Run(config *onet.SimulationConfig) error {
 	for round := 0; round < sim.Rounds; round++ {
-		log.Lvl1("Starting round", round)
 
 		rooti, err := config.Overlay.CreateProtocol("AddRmServer", config.Tree, onet.NilServiceID)
 
@@ -72,8 +71,6 @@ func (sim *AddRmSimulation) Run(config *onet.SimulationConfig) error {
 		for i := range ct {
 			ct[i] = *libunlynx.EncryptInt(pubKey, 1)
 		}
-
-		log.Lvl1("starting protocol with ", len(ct), " responses")
 
 		root.ProtocolInstance().(*protocolsunlynxutils.AddRmServerProtocol).TargetOfTransformation = ct
 		root.ProtocolInstance().(*protocolsunlynxutils.AddRmServerProtocol).Proofs = sim.Proofs


### PR DESCRIPTION
`lib.{Start,End}Parallelize` are useful for concurrent computation, but it lack a standard way to return errors. With this PR, `wg.Done` takes an error argument which get returned by `wg.Wait`.